### PR TITLE
Ext point triggers

### DIFF
--- a/lib/cylc/network/ext_trigger.py
+++ b/lib/cylc/network/ext_trigger.py
@@ -73,17 +73,8 @@ class ExtTriggerServer(PyroServer):
         for trig, satisfied in itask.state.external_triggers.items():
             if satisfied:
                 continue
-
-            # Substitute the cycle point for matching - allow the original
-            # trigger string to persist to avoid negative downstream impacts.
-            if '$CYLC_TASK_CYCLE_POINT' in trig:
-                # Substitute the cycle point for matching
-                tmsg = trig.replace('$CYLC_TASK_CYCLE_POINT', str(itask.point))
-            else:
-                tmsg = trig
-
             for qmsg, qid in queued:
-                if tmsg == qmsg:
+                if trig == qmsg:
                     # Matched.
                     name, point_string = TaskID.split(itask.identity)
                     # Set trigger satisfied.

--- a/lib/cylc/task_state.py
+++ b/lib/cylc/task_state.py
@@ -246,6 +246,9 @@ class TaskState(object):
         # External Triggers.
         self.external_triggers = {}
         for ext in tdef.external_triggers:
+            # Allow cycle-point-specific external triggers - GitHub #1893.
+            if '$CYLC_TASK_CYCLE_POINT' in ext:
+                ext = ext.replace('$CYLC_TASK_CYCLE_POINT', str(point))
             # set unsatisfied
             self.external_triggers[ext] = False
 

--- a/tests/ext-trigger/02-cycle-point.t
+++ b/tests/ext-trigger/02-cycle-point.t
@@ -1,0 +1,32 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2016 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Test GitHub #1893 - cycle point specific external triggers.
+
+. "$(dirname "$0")/test_header"
+
+set_test_number 2
+
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}" 
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+
+suite_run_ok "${TEST_NAME_BASE}-run" cylc run --no-detach "${SUITE_NAME}"
+
+purge_suite "${SUITE_NAME}"
+
+exit

--- a/tests/ext-trigger/02-cycle-point/suite.rc
+++ b/tests/ext-trigger/02-cycle-point/suite.rc
@@ -1,0 +1,25 @@
+title = "Test for Github Issue 1893"
+description = """Cycle-point specific external triggering in a date-time
+cycling suite.  The suite will time out and abort if the ext trigger fails."""
+
+[cylc]
+    cycle point format = %Y
+    [[event hooks]]
+        abort on timeout = True
+        timeout = PT30S
+[scheduling]
+    initial cycle point = 2020
+    final cycle point = 2020
+    [[special tasks]]
+        external-trigger = ext("cheese on toast for $CYLC_TASK_CYCLE_POINT")
+    [[dependencies]]
+        [[[P1Y]]]
+            graph = ext & trig
+[runtime]
+    [[ext]]
+        # Externally triggered task.
+        script = echo $CYLC_EXT_TRIGGER_ID
+    [[trig]]
+        # Task to do the "external" triggering.
+        script = cylc ext-trigger $CYLC_SUITE_NAME \
+            "cheese on toast for $CYLC_TASK_CYCLE_POINT" "blarghh!"


### PR DESCRIPTION
Tim - as discussed on cylc/cylc/#1893: a change to the location of your string replacement, and an automated test to support this functionality (passes here with "cylc test-battery tests/ext-trigger/02-cycle-point.t", fails on current master).  If you agree, please merge to your branch and hence to the main PR...
